### PR TITLE
Add action to generate snapshot builds

### DIFF
--- a/lib/fastlane/plugin/emerge/actions/emerge_action.rb
+++ b/lib/fastlane/plugin/emerge/actions/emerge_action.rb
@@ -50,7 +50,7 @@ module Fastlane
                 FileUtils.cp(l, linkmap_folder)
               end
             end
-            copy_config(config_path, "#{d}/archive.xcarchive")
+            Helper::EmergeHelper.copy_config(config_path, "#{d}/archive.xcarchive")
             FileUtils.cp_r(file_path, application_folder)
             copy_dsyms("#{absolute_path.dirname}/*.dsym", dsym_folder)
             copy_dsyms("#{absolute_path.dirname}/*/*.dsym", dsym_folder)
@@ -73,7 +73,7 @@ module Fastlane
               FileUtils.cp(l, linkmap_folder)
             end
           end
-          copy_config(config_path, file_path)
+          Helper::EmergeHelper.copy_config(config_path, file_path)
           Actions::ZipAction.run(
             path: file_path,
             output_path: zip_path,
@@ -107,19 +107,6 @@ module Fastlane
           UI.message("Found dSYM: #{Pathname.new(filename).basename}")
           FileUtils.cp_r(filename, to)
         end
-      end
-
-      def self.copy_config(config_path, tmp_dir)
-        return if config_path.nil?
-
-        expanded_path = File.expand_path(config_path)
-        unless File.exist?(expanded_path)
-          UI.error("No config file found at path '#{expanded_path}'.\nUploading without config file")
-          return
-        end
-
-        emerge_config_path = "#{tmp_dir}/emerge_config.yaml"
-        FileUtils.cp(expanded_path, emerge_config_path)
       end
 
       def self.description

--- a/lib/fastlane/plugin/emerge/actions/emerge_action.rb
+++ b/lib/fastlane/plugin/emerge/actions/emerge_action.rb
@@ -88,62 +88,18 @@ module Fastlane
           return
         end
 
-        filename = File.basename(file_path)
-        url = 'https://api.emergetools.com/upload'
         params = {
-          filename: filename
+          prNumber: pr_number,
+          branch: branch,
+          sha: sha,
+          baseSha: base_sha,
+          repoName: repo_name,
+          gitlabProjectId: gitlab_project_id,
+          orderFileVersion: order_file_version,
+          tag: tag || "default"
         }
-        if pr_number
-          params[:prNumber] = pr_number
-        end
-        if branch
-          params[:branch] = branch
-        end
-        if sha
-          params[:sha] = sha
-        end
-        if base_sha
-          params[:baseSha] = base_sha
-        end
-        if repo_name
-          params[:repoName] = repo_name
-        end
-        if gitlab_project_id
-          params[:gitlabProjectId] = gitlab_project_id
-        end
-        if order_file_version
-          params[:orderFileVersion] = order_file_version
-        end
-        params[:tag] = tag || "default"
-        FastlaneCore::PrintTable.print_values(
-          config: params,
-          hide_keys: [],
-          title: "Summary for Emerge #{Fastlane::Emerge::VERSION}"
-        )
-        resp = Faraday.post(
-          url,
-          params.to_json,
-          'Content-Type' => 'application/json', 'X-API-Token' => api_token, 'User-Agent' => "fastlane-plugin-emerge/#{Fastlane::Emerge::VERSION}"
-        )
-        case resp.status
-        when 200
-          json = JSON.parse(resp.body)
-          upload_id = json["upload_id"]
-          upload_url = json["uploadURL"]
-          warning = json["warning"]
-          if warning
-            UI.important(warning)
-          end
-          return Helper::EmergeHelper.perform_upload(upload_url, upload_id, file_path)
-        when 403
-          UI.error("Invalid API token")
-        when 400
-          UI.error("Invalid parameters")
-          json = JSON.parse(resp.body)
-          UI.error("Error: #{json['errorMessage']}")
-        else
-          UI.error("Upload failed")
-        end
+        upload_id = Helper::EmergeHelper.perform_upload(api_token, params, file_path)
+        UI.success("🎉 Your app is processing, you can find the results at https://emergetools.com/build/#{upload_id}")
       end
 
       def self.copy_dsyms(from, to)

--- a/lib/fastlane/plugin/emerge/actions/emerge_snapshot_action.rb
+++ b/lib/fastlane/plugin/emerge/actions/emerge_snapshot_action.rb
@@ -34,7 +34,6 @@ module Fastlane
             configuration: configuration,
             skip_codesigning: true,
             clean: true,
-            include_symbols: true,
             export_method: "development",
             export_team_id: team_id,
             skip_package_ipa: true,
@@ -44,11 +43,6 @@ module Fastlane
 
           Helper::EmergeHelper.copy_config(config_path, archive_path)
           Xcodeproj::Plist.write_to_path({ "NAME" => "Emerge Upload" }, "#{archive_path}/Info.plist")
-          dsym_path = "#{archive_path}/dSYMs"
-          if Dir.exist?(dsym_path)
-            UI.message("Removing dSYMs from xcarchive")
-            FileUtils.rm_rf(dsym_path)
-          end
 
           zip_file_path = "#{temp_dir}/build/archive.xcarchive.zip"
           ZipAction.run(

--- a/lib/fastlane/plugin/emerge/actions/emerge_snapshot_action.rb
+++ b/lib/fastlane/plugin/emerge/actions/emerge_snapshot_action.rb
@@ -41,7 +41,7 @@ module Fastlane
             archive_path: archive_path
           )
 
-          copy_config(config_path, archive_path)
+          Helper::EmergeHelper.copy_config(config_path, archive_path)
           Xcodeproj::Plist.write_to_path({ "NAME" => "Emerge Upload" }, "#{archive_path}/Info.plist")
           dsym_path = "#{archive_path}/dSYMs"
           if Dir.exist?(dsym_path)
@@ -70,19 +70,6 @@ module Fastlane
           upload_id = Helper::EmergeHelper.perform_upload(api_token, params, zip_file_path)
           UI.success("🎉 Your app is processing, you can find the results at https://emergetools.com/snapshot/#{upload_id}")
         end
-      end
-
-      def self.copy_config(config_path, tmp_dir)
-        return if config_path.nil?
-
-        expanded_path = File.expand_path(config_path)
-        unless File.exist?(expanded_path)
-          UI.error("No config file found at path '#{expanded_path}'.\nUploading without config file")
-          return
-        end
-
-        emerge_config_path = "#{tmp_dir}/emerge_config.yaml"
-        FileUtils.cp(expanded_path, emerge_config_path)
       end
 
       def self.description

--- a/lib/fastlane/plugin/emerge/actions/emerge_snapshot_action.rb
+++ b/lib/fastlane/plugin/emerge/actions/emerge_snapshot_action.rb
@@ -1,0 +1,160 @@
+require 'fastlane/action'
+require 'fastlane_core/print_table'
+require_relative '../helper/emerge_helper'
+require_relative '../helper/git'
+require_relative '../helper/github'
+require 'pathname'
+require 'tmpdir'
+require 'json'
+require 'fileutils'
+
+module Fastlane
+  module Actions
+    class EmergeSnapshotAction < Action
+      def self.run(params)
+        api_token = params[:api_token]
+
+        git_params = Helper::EmergeHelper.make_git_params
+        pr_number = params[:pr_number] || git_params.pr_number
+        branch = params[:branch] || git_params.branch
+        sha = params[:sha] || git_params.sha
+        base_sha = params[:base_sha] || git_params.base_sha
+        repo_name = params[:repo_name] || git_params.repo_name
+        gitlab_project_id = params[:gitlab_project_id]
+        tag = params[:tag]
+        config_path = params[:config_path]
+        scheme = params[:scheme]
+        configuration = params[:configuration]
+
+        Dir.mktmpdir do |temp_dir|
+          archive_path = "#{temp_dir}/build/snapshot.xcarchive"
+          other_action.gym(
+            scheme: scheme,
+            configuration: configuration,
+            skip_codesigning: true,
+            clean: true,
+            include_symbols: true,
+            export_method: "development",
+            export_team_id: ENV['APPLE_TEAM_ID'],
+            skip_package_ipa: true,
+            output_directory: "#{temp_dir}/build",
+            archive_path: archive_path
+          )
+
+          copy_config(config_path, archive_path)
+          Xcodeproj::Plist.write_to_path({ "NAME" => "Emerge Upload" }, "#{archive_path}/Info.plist")
+          dsym_path = "#{archive_path}/dSYMs"
+          if Dir.exist?(dsym_path)
+            UI.message("Removing dSYMs from xcarchive")
+            FileUtils.rm_rf(dsym_path)
+          end
+
+          zip_file_path = "#{temp_dir}/build/archive.xcarchive.zip"
+          ZipAction.run(
+            path: archive_path,
+            output_path: zip_file_path,
+            exclude: [],
+            include: []
+          )
+
+          params = {
+            appIdSuffix: 'snapshots',
+            prNumber: pr_number,
+            branch: branch,
+            sha: sha,
+            baseSha: base_sha,
+            repoName: repo_name,
+            gitlabProjectId: gitlab_project_id,
+            tag: tag || "default"
+          }
+          upload_id = Helper::EmergeHelper.perform_upload(api_token, params, zip_file_path)
+          UI.success("🎉 Your app is processing, you can find the results at https://emergetools.com/snapshot/#{upload_id}")
+        end
+      end
+
+      def self.copy_config(config_path, tmp_dir)
+        return if config_path.nil?
+
+        expanded_path = File.expand_path(config_path)
+        unless File.exist?(expanded_path)
+          UI.error("No config file found at path '#{expanded_path}'.\nUploading without config file")
+          return
+        end
+
+        emerge_config_path = "#{tmp_dir}/emerge_config.yaml"
+        FileUtils.cp(expanded_path, emerge_config_path)
+      end
+
+      def self.description
+        "Fastlane plugin for Emerge to generate iOS snapshots"
+      end
+
+      def self.authors
+        ["Emerge Tools"]
+      end
+
+      def self.return_value
+        "If successful, returns the upload id of the generated snapshot build"
+      end
+
+      def self.details
+        ""
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :api_token,
+                                       env_name: "EMERGE_API_TOKEN",
+                                       description: "An API token for Emerge",
+                                       optional: false,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :scheme,
+                                       description: "The scheme of your app to build",
+                                       optional: false,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :configuration,
+                                       description: "The configuration of your app to use",
+                                       optional: false,
+                                       default_value: "Debug",
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :config_path,
+                                       description: "Path to Emerge YAML config path",
+                                       optional: true,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :pr_number,
+                                       description: "The PR number that triggered this upload",
+                                       optional: true,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :branch,
+                                       description: "The current git branch",
+                                       optional: true,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :sha,
+                                       description: "The git SHA that triggered this build",
+                                       optional: true,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :base_sha,
+                                       description: "The git SHA of the base build",
+                                       optional: true,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :repo_name,
+                                       description: "Full name of the respository this upload was triggered from. For example: EmergeTools/Emerge",
+                                       optional: true,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :gitlab_project_id,
+                                       description: "Id of the gitlab project this upload was triggered from",
+                                       optional: true,
+                                       type: Integer),
+          FastlaneCore::ConfigItem.new(key: :tag,
+                                       description: "String to label the build. Useful for grouping builds together in our dashboard, like development, default, or pull-request",
+                                       optional: true,
+                                       type: String)
+        ]
+      end
+
+      def self.is_supported?(platform)
+        platform == :ios
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/emerge/actions/emerge_snapshot_action.rb
+++ b/lib/fastlane/plugin/emerge/actions/emerge_snapshot_action.rb
@@ -25,6 +25,7 @@ module Fastlane
         config_path = params[:config_path]
         scheme = params[:scheme]
         configuration = params[:configuration]
+        team_id = params[:team_id] || CredentialsManager::AppfileConfig.try_fetch_value(:team_id)
 
         Dir.mktmpdir do |temp_dir|
           archive_path = "#{temp_dir}/build/snapshot.xcarchive"
@@ -35,7 +36,7 @@ module Fastlane
             clean: true,
             include_symbols: true,
             export_method: "development",
-            export_team_id: ENV['APPLE_TEAM_ID'],
+            export_team_id: team_id,
             skip_package_ipa: true,
             output_directory: "#{temp_dir}/build",
             archive_path: archive_path
@@ -103,6 +104,11 @@ module Fastlane
                                        description: "The configuration of your app to use",
                                        optional: false,
                                        default_value: "Debug",
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :team_id,
+                                       env_name: "EXPORT_TEAM_ID",
+                                       description: "The Apple Team ID to use for exporting the archive. If not provided, we will try to use the team_id from the Appfile",
+                                       optional: true,
                                        type: String),
           FastlaneCore::ConfigItem.new(key: :config_path,
                                        description: "Path to Emerge YAML config path",

--- a/lib/fastlane/plugin/emerge/helper/emerge_helper.rb
+++ b/lib/fastlane/plugin/emerge/helper/emerge_helper.rb
@@ -21,15 +21,13 @@ module Fastlane
       API_URL = 'https://api.emergetools.com/upload'.freeze
 
       def self.perform_upload(api_token, params, file_path)
-        begin
-          cleaned_params = clean_params(params)
-          print_summary(cleaned_params)
+        cleaned_params = clean_params(params)
+        print_summary(cleaned_params)
 
-          upload_response = create_upload(api_token, cleaned_params)
-          handle_upload_response(api_token, upload_response, file_path)
-        rescue StandardError => e
-          UI.user_error!(e.message)
-        end
+        upload_response = create_upload(api_token, cleaned_params)
+        handle_upload_response(api_token, upload_response, file_path)
+      rescue StandardError => e
+        UI.user_error!(e.message)
       end
 
       def self.make_git_params
@@ -52,6 +50,19 @@ module Fastlane
                      end
         UI.message("Got git result #{git_result.inspect}")
         git_result
+      end
+
+      def self.copy_config(config_path, tmp_dir)
+        return if config_path.nil?
+
+        expanded_path = File.expand_path(config_path)
+        unless File.exist?(expanded_path)
+          UI.error("No config file found at path '#{expanded_path}'.\nUploading without config file")
+          return
+        end
+
+        emerge_config_path = "#{tmp_dir}/emerge_config.yaml"
+        FileUtils.cp(expanded_path, emerge_config_path)
       end
 
       private_class_method

--- a/lib/fastlane/plugin/emerge/helper/emerge_helper.rb
+++ b/lib/fastlane/plugin/emerge/helper/emerge_helper.rb
@@ -110,6 +110,11 @@ module Fastlane
         upload_url = response.fetch('uploadURL')
         upload_id = response.fetch('upload_id')
 
+        warning = response.dig('warning')
+        if warning
+          UI.important(warning)
+        end
+
         UI.message('Starting zip file upload')
         upload_file(api_token, upload_url, file_path)
         upload_id

--- a/lib/fastlane/plugin/emerge/version.rb
+++ b/lib/fastlane/plugin/emerge/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Emerge
-    VERSION = "0.8.0"
+    VERSION = "0.9.0"
   end
 end


### PR DESCRIPTION
Allows users to trigger snapshots via:
```
emerge_snapshot(scheme: "Hacker News")
```
which attempts to build the app with `gym()` using the Debug scheme (overridable if needed). I also do some steps like removing dSYM files which aren't needed.